### PR TITLE
Better support for nested python projects

### DIFF
--- a/virtualenv-autodetect.plugin.zsh
+++ b/virtualenv-autodetect.plugin.zsh
@@ -1,0 +1,1 @@
+virtualenv-autodetect.sh

--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -40,7 +40,7 @@ _remove_from_pythonpath() {
 _get_virtualenv_path() {
     # Find subdir of given one that is a virtualenv dir.
     _find_virtualenv_subdir() {
-        result=$(find $1 -maxdepth 2 -type d -name 'bin' -exec find {} -name 'activate' \; 2> /dev/null)
+        result=$(find $1 -maxdepth 2 -type d -name 'bin' -exec find {} -maxdepth 1 -name 'activate' \; 2> /dev/null)
         if [ -n "$result" ]; then
             if [ -n "$(head -1 $result | grep "source bin/activate" 2> /dev/null)" ]; then
                 echo $result

--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -86,6 +86,6 @@ _virtualenv_auto_activate
 
 # Activate on directory change.
 # Zsh.
-chpwd_functions=(_virtualenv_auto_activate)
+chpwd_functions+=(_virtualenv_auto_activate)
 # Bash.
 export PROMPT_COMMAND="_bash_chpwd_function _virtualenv_auto_activate"

--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -16,7 +16,6 @@ _virtualenv_auto_activate() {
         if [ "$VIRTUAL_ENV" != "${_virtualenv_path%/bin/activate}" ]
         then
             _remove_from_pythonpath     # Remove any previous VE path
-            VIRTUAL_ENV_DISABLE_PROMPT=1
             source "$_virtualenv_path"
             _add_to_pythonpath "$VIRTUAL_ENV"
         fi

--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -1,5 +1,5 @@
 # virtualenv-autodetect.sh
-# 
+#
 # Installation:
 # Add this line to your .zshenv, .bashrc or .bash-profile:
 #
@@ -7,17 +7,16 @@
 
 # https://github.com/egilewski/virtualenv-autodetect
 
-_VIRTUALENV_ACTIVATION_SCRIPT_PATH="bin/activate"
 
 _virtualenv_auto_activate() {
     _virtualenv_path=$(_get_virtualenv_path)
     if [ -e "$_virtualenv_path" ]
     then
         # Check if already activated to avoid redundant activation.
-        if [ "$VIRTUAL_ENV" != $(readlink -f "$_virtualenv_path") ]
+        if [ "$VIRTUAL_ENV" != "$_virtualenv_path" ]
         then
             VIRTUAL_ENV_DISABLE_PROMPT=1
-            source "$_virtualenv_path/$_VIRTUALENV_ACTIVATION_SCRIPT_PATH"
+            source "$_virtualenv_path"
         fi
     else
         deactivate 2>/dev/null
@@ -28,23 +27,16 @@ _virtualenv_auto_activate() {
 _get_virtualenv_path() {
     # Find subdir of given one that is a virtualenv dir.
     _find_virtualenv_subdir() {
-        for i in $(find $1 -maxdepth 1 -printf %f\\n)
-        do
-            if [ -e "$1/$i/$_VIRTUALENV_ACTIVATION_SCRIPT_PATH" ]
-            then
-                echo "$i"
-                break
-            fi
-        done
+        find $1 -maxdepth 2 -type d -name 'bin' -exec find {} -name 'activate' \; 2> /dev/null
     }
 
     _current_dir="$PWD"
     while true
     do
         _virtualenv_subdir=$(_find_virtualenv_subdir "$_current_dir")
-        if [ "$_virtualenv_subdir" ]
+        if [ -n "$_virtualenv_subdir" ]
         then
-            echo "$_current_dir/$_virtualenv_subdir"
+            echo "$_virtualenv_subdir"
             return
         else
             if [[ "$_current_dir" != "/" ]]

--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -27,7 +27,12 @@ _virtualenv_auto_activate() {
 _get_virtualenv_path() {
     # Find subdir of given one that is a virtualenv dir.
     _find_virtualenv_subdir() {
-        find $1 -maxdepth 2 -type d -name 'bin' -exec find {} -name 'activate' \; 2> /dev/null
+        result=$(find $1 -maxdepth 2 -type d -name 'bin' -exec find {} -name 'activate' \; 2> /dev/null)
+        if [ -n "$result" ]; then
+            if [ -n "$(head -1 $result | grep "source bin/activate" 2> /dev/null)" ]; then
+                echo $result
+            fi
+        fi
     }
 
     _current_dir="$PWD"
@@ -49,7 +54,7 @@ _get_virtualenv_path() {
     done
 }
 
-# Execute given function if derectory changed.
+# Execute given function if directory changed.
 # Unlike in Zsh's "chpwd_functions" won't work with "cd .".
 _bash_chpwd_function() {
     if [ "$PWD" != "$_myoldpwd" ]

--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -13,14 +13,25 @@ _virtualenv_auto_activate() {
     if [ -e "$_virtualenv_path" ]
     then
         # Check if already activated to avoid redundant activation.
-        if [ "$VIRTUAL_ENV" != "$_virtualenv_path" ]
+        if [ "$VIRTUAL_ENV" != "${_virtualenv_path#/bin/activate}" ]
         then
             VIRTUAL_ENV_DISABLE_PROMPT=1
             source "$_virtualenv_path"
+            _add_to_pythonpath "$VIRTUAL_ENV"
         fi
     else
         deactivate 2>/dev/null
+        _remove_from_pythonpath
     fi
+}
+
+_add_to_pythonpath() {
+    sp=$(find $1 -type d -name 'site-packages')
+    export PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}$sp
+}
+
+_remove_from_pythonpath() {
+    export PYTHONPATH=$(echo $PYTHONPATH | perl -pe 's%(^|:)(/?[a-zA-Z0-9_\-\.]*/)*site-packages($|:)%%')
 }
 
 # Get absolute path to virtualenv dir in current dir or one of it's parents.


### PR DESCRIPTION
When entering a folder that contains lots of Python projects, this prevents the activation of an environment until we actually enter on of the project folders.

This also improves the performance of deactivating and exiting the method if we are already inside an Virtual environment or if we leave the virtual environment's parent directory.